### PR TITLE
Maintenance v2.1

### DIFF
--- a/tasks/maintenance/bots/unreviewed_article/core.py
+++ b/tasks/maintenance/bots/unreviewed_article/core.py
@@ -96,7 +96,7 @@ class UnreviewedArticle:
             newText += text
             self._page.text = newText
             if self._page.exists() and (not self.page.isRedirectPage()):
-                self._page.save("بوت:صيانة V2.0، أضاف وسم مقالة غير مراجعة")
+                self._page.save("بوت:صيانة V2.1، أضاف وسم مقالة غير مراجعة")
 
     def remove_template(self):
         """
@@ -108,7 +108,7 @@ class UnreviewedArticle:
         if new_text != text:
             self.page.text = new_text
             if self._page.exists() and (not self.page.isRedirectPage()):
-                self._page.save("بوت:صيانة V2.0، حذف وسم مقالة غير مراجعة")
+                self._page.save("بوت:صيانة V2.1، حذف وسم مقالة غير مراجعة")
 
     def check(self):
         """

--- a/tasks/maintenance/check.py
+++ b/tasks/maintenance/check.py
@@ -5,46 +5,10 @@ import sqlite3
 
 import pywikibot
 
-from bots.unreviewed_article.core import UnreviewedArticle
+
+from module import create_database_table,get_unreviewed_articles,process_unreviewed_article
 
 
-def create_database_table():
-    home_path = os.path.expanduser("~")
-    database_path = os.path.join(home_path, "maintenance.db")
-    conn = sqlite3.connect(database_path)
-    cursor = conn.cursor()
-
-    # Create the table with a status column
-    cursor.execute(
-        '''CREATE TABLE IF NOT EXISTS pages (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, status INTEGER, date TIMESTAMP DEFAULT CURRENT_TIMESTAMP)''')
-
-    return conn, cursor
-
-
-def get_unreviewed_articles(cursor):
-    cursor.execute("SELECT id, title FROM pages WHERE status=0 ORDER BY date ASC LIMIT 100")
-    rows = cursor.fetchall()
-    return rows
-
-
-def process_unreviewed_article(site, cursor, conn, id, title):
-    try:
-        cursor.execute("UPDATE pages SET status = 1 WHERE id = ?", (id,))
-        conn.commit()
-        page = UnreviewedArticle(site)
-        page.title = title
-        page.load_page()
-        if not page.check():
-            page.add_template()
-        else:
-            page.remove_template()
-        cursor.execute("DELETE FROM pages WHERE id = ?", (id,))
-        conn.commit()
-    except Exception as e:
-        print(f"An error occurred while processing {title}: {e}")
-        cursor.execute("UPDATE pages SET status = 0, date = date + ? WHERE id = ?",
-                       (datetime.timedelta(hours=1), id))
-        conn.commit()
 
 
 def main():

--- a/tasks/maintenance/module.py
+++ b/tasks/maintenance/module.py
@@ -1,0 +1,143 @@
+import sqlite3
+
+import pywikibot
+import pymysql
+from pywikibot import config as _config
+import os
+import datetime
+import pywikibot.flow
+
+
+class Database():
+    """A class for interacting with a database.
+
+    Attributes:
+        _connection (pymysql.connections.Connection): A connection to the database.
+        _query (str): The current SQL query.
+        result (list): The result of the last executed query.
+    """
+
+    def __init__(self):
+        """Initializes the Database with the connection and query attributes set to None, and result set to an empty list."""
+        self._connection = None
+        self._query = ""
+        self.result = []
+
+    @property
+    def connection(self):
+        """Returns the current connection to the database. If none exists, a new connection is established and returned.
+
+        Returns:
+            pymysql.connections.Connection: A connection to the database.
+        """
+
+        if self._connection is not None:
+            return self._connection
+        else:
+            return pymysql.connect(
+                host=_config.db_hostname_format.format("arwiki"),
+                read_default_file=_config.db_connect_file,
+                db=_config.db_name_format.format("arwiki"),
+                charset='utf8mb4',
+                port=_config.db_port,
+                cursorclass=pymysql.cursors.DictCursor,
+            )
+
+    @property
+    def query(self):
+        """Returns the current SQL query.
+
+        Returns:
+            str: The current SQL query.
+        """
+        return self._query
+
+    @query.setter
+    def query(self, value):
+        """Sets the current SQL query and replaces placeholders with the appropriate values.
+
+        Args:
+            value (str): The new SQL query.
+        """
+        self._query = value
+
+    def get_content_from_database(self):
+        """Executes the current SQL query and stores the result in the `result` attribute.
+
+        Raises:
+            pymysql.err.OperationalError: If a connection to the database cannot be established.
+        """
+        try:
+            # Create a cursor page
+            with self.connection.cursor() as cursor:
+                # Execute the SELECT statement
+                cursor.execute(self._query)
+                # Fetch all the rows of the result
+                self.result = cursor.fetchall()
+        finally:
+            # Close the connection
+            self.connection.close()
+
+    @connection.setter
+    def connection(self, value):
+        """Sets the current connection to the database.
+
+        Args:
+            value (pymysql.connections.Connection): The new connection to the database.
+        """
+        self._connection = value
+
+
+
+def create_database_table():
+    home_path = os.path.expanduser("~")
+    database_path = os.path.join(home_path, "maintenance.db")
+    conn = sqlite3.connect(database_path)
+    cursor = conn.cursor()
+
+    # Create the table with a status column
+    cursor.execute(
+        '''CREATE TABLE IF NOT EXISTS pages (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, status INTEGER, date TIMESTAMP DEFAULT CURRENT_TIMESTAMP)''')
+
+    return conn, cursor
+
+
+def get_pages(start):
+    query = """SELECT pl_2_title
+FROM (
+    SELECT DISTINCT log_title AS "pl_2_title"
+    FROM logging
+    WHERE log_type IN ("review") 
+    AND log_namespace IN (0)
+    AND log_timestamp > DATE_SUB( now(), INTERVAL MINUTE_SUB_NUMBER MINUTE )
+    UNION
+    SELECT DISTINCT page.page_title AS "pl_2_title"
+    FROM revision
+    INNER JOIN page ON revision.rev_page = page.page_id
+    WHERE page.page_namespace IN (0)
+    AND rev_timestamp > DATE_SUB( now(), INTERVAL MINUTE_SUB_NUMBER MINUTE ) and page_is_redirect = 0
+
+) AS pages_list"""
+    database = Database()
+    database.query = query.replace("MINUTE_SUB_NUMBER", str(start))
+    database.get_content_from_database()
+    gen = []
+    for row in database.result:
+        title = str(row['pl_2_title'], 'utf-8')
+        gen.append(title)
+
+    gen = set(gen)
+    return gen
+
+
+def save_pages_to_db(gen, conn, cursor):
+    for entry in gen:
+        try:
+            title = entry
+            cursor.execute("SELECT * FROM pages WHERE title = ?", (title,))
+            if cursor.fetchone() is None:
+                print("added : " + title)
+                cursor.execute("INSERT INTO pages (title, status) VALUES (?, 0)", (title,))
+            conn.commit()
+        except sqlite3.Error as e:
+            print(f"An error occurred while inserting the title {entry.title()} into the database: {e}")

--- a/tasks/maintenance/read.py
+++ b/tasks/maintenance/read.py
@@ -1,65 +1,13 @@
-import datetime
-import itertools
-import os
-from pywikibot import pagegenerators
-import time
-import sqlite3
-import pywikibot
 import sys
-
-
-def create_database_table():
-    home_path = os.path.expanduser("~")
-    database_path = os.path.join(home_path, "maintenance.db")
-    conn = sqlite3.connect(database_path)
-    cursor = conn.cursor()
-
-    # Create the table with a status column
-    cursor.execute(
-        '''CREATE TABLE IF NOT EXISTS pages (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, status INTEGER, date TIMESTAMP DEFAULT CURRENT_TIMESTAMP)''')
-
-    return conn, cursor
-
-
-def get_pages(site, start, end):
-    gen1 = pagegenerators.RecentChangesPageGenerator(site=site, start=start, end=end, namespaces=[0], reverse=True)
-    gen2 = pagegenerators.LogeventsPageGenerator(logtype="review", total=3000, site=site, start=start, end=end,
-                                                 namespace=0, reverse=True)
-    merged_gen = itertools.chain(gen1, gen2)
-    gen = set(merged_gen)
-
-    # gen = filter(lambda page: page.exists(), gen)
-    return gen
-
-
-def save_pages_to_db(site, gen, conn, cursor):
-    for entry in gen:
-        page1 = pywikibot.Page(site, entry.title())
-        if not page1.isRedirectPage():
-            time.sleep(1)
-            try:
-                title = entry.title()
-                cursor.execute("SELECT * FROM pages WHERE title = ?", (title,))
-                if cursor.fetchone() is None:
-                    print("added : " + title)
-                    cursor.execute("INSERT INTO pages (title, status) VALUES (?, 0)", (title,))
-                conn.commit()
-            except sqlite3.Error as e:
-                print(f"An error occurred while inserting the title {entry.title()} into the database: {e}")
+from module import create_database_table, get_pages, save_pages_to_db
 
 
 def main(*args: str) -> int:
     try:
         time_before_start = int(sys.argv[1])
-        site = pywikibot.Site()
-        start = pywikibot.Timestamp.now() - datetime.timedelta(minutes=time_before_start)
-        end = pywikibot.Timestamp.now()
-        pages = get_pages(site, start, end)
-
+        pages = get_pages(time_before_start)
         conn, cursor = create_database_table()
-
-        save_pages_to_db(site, pages, conn, cursor)
-
+        save_pages_to_db(pages, conn, cursor)
         conn.close()
     except Exception as e:
         print(f"An error occurred: {e}")

--- a/tasks/maintenance/test.py
+++ b/tasks/maintenance/test.py
@@ -1,4 +1,0 @@
-import pywikibot
-site = pywikibot.Site()
-page = pywikibot.Page(site,"عقيد_(رتبة_عسكرية)")
-print(page.text)

--- a/tasks/maintenance/test.py
+++ b/tasks/maintenance/test.py
@@ -1,0 +1,4 @@
+import pywikibot
+site = pywikibot.Site()
+page = pywikibot.Page(site,"عقيد_(رتبة_عسكرية)")
+print(page.text)


### PR DESCRIPTION
- جعل جلب قائمة المقالات تاتي من قاعده البيانات بشكل مباشر بدون استخدام pagegenerators 
```

SELECT pl_2_title
FROM (
    SELECT DISTINCT log_title AS "pl_2_title"
    FROM logging
    WHERE log_type IN ("review") 
    AND log_namespace IN (0)
    AND log_timestamp > DATE_SUB( now(), INTERVAL 5 MINUTE )
    UNION
    SELECT DISTINCT page.page_title AS "pl_2_title"
    FROM revision
    INNER JOIN page ON revision.rev_page = page.page_id
    WHERE page.page_namespace IN (0)
    AND rev_timestamp > DATE_SUB( now(), INTERVAL 5 MINUTE ) and page_is_redirect = 0
 	
) AS pages_list
```
- حذف بعض الشروط المكررة لتخفيف الضغط علي السيرفر 
    -- مثلا شروط التحقق ان الصفحه موجوده وغيرها كون هذه الشروط يتم التحقق منها قبل حفظ الصفحه لذلك هي مكررة
- دمج بعض الاكواد المكررة تميهدا لاضافه باقي المهام الصيانه في ملف module.py
