### PR TITLE
تحديث الكود بوت (ويكيبيديا: إخطار الإداريين/ أسماء مستخدمين للفحص) (v1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2023-02-28
+### Changed
+- تم تحديث الكود بوت (ويكيبيديا: إخطار الإداريين/ أسماء مستخدمين للفحص) الي الاصدار  (v1.3) حتي يجعل صفحة (ويكيبيديا:إخطار الإداريين/أسماء مستخدمين للفحص/تشغيل البوت) فارغه عند التحديث ([#95](https://github.com/loka1/LokasBot/pull/95))
+
+
 ## [1.0.1] - 2023-02-27
 ### Fixed
-- تم تحديث الكود بوت (ويكيبيديا: إخطار الإداريين/ أسماء مستخدمين للفحص) لمنع التشغيل التلقيائية للكود عند استيراد المكتبات ([[#92]](https://github.com/loka1/LokasBot/pull/93))
+- تم تحديث الكود بوت (ويكيبيديا: إخطار الإداريين/ أسماء مستخدمين للفحص) لمنع التشغيل التلقيائية للكود عند استيراد المكتبات ([#94](https://github.com/loka1/LokasBot/pull/94))
 
 ## [1.0.0] - 2023-02-27
 ### Added

--- a/tasks/check_usernames/check/check.py
+++ b/tasks/check_usernames/check/check.py
@@ -26,7 +26,7 @@ class Check:
         return False
 
     def reload(self):
-        self.page.text = "لا"
+        self.page.text = ""
         self.page.save("بوت:تم")
 
 


### PR DESCRIPTION
تم تحديث الكود بوت (ويكيبيديا: إخطار الإداريين/ أسماء مستخدمين للفحص) الي الاصدار (v1.3) حتي يجعل صفحة (ويكيبيديا:إخطار الإداريين/أسماء مستخدمين للفحص/تشغيل البوت) فارغه عند التحديث